### PR TITLE
Avoiding infinite waiting loops

### DIFF
--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 echo "Waiting for RabbitMQ to Start..."
 
-while ! nc -z $RABBITMQ_SERVICE_NAME 5672; do
-  sleep 0.1
+until timeout 1 bash -c "cat < /dev/null > /dev/tcp/${RABBITMQ_SERVICE_NAME}/5672"; do
+        >&2 echo "Waiting for RabbitMQ at \"${RABBITMQ_SERVICE_NAME}:5672\"..."
+        sleep 1
 done
+
+#while ! nc -z $RABBITMQ_SERVICE_NAME 5672; do
+  #sleep 0.1
+#done
 
 echo "RabbitMQ started"
 

--- a/media_server/Dockerfile
+++ b/media_server/Dockerfile
@@ -1,11 +1,5 @@
 FROM node:14.15.1
 
-
-# install netcat
-RUN apt-get update && \
-    apt-get -y install netcat && \
-    apt-get clean
-
 EXPOSE 3001
 
 # set working directory

--- a/media_server/entrypoint.sh
+++ b/media_server/entrypoint.sh
@@ -3,10 +3,10 @@
 RABBITMQ_HOST=$1
 
 echo $RABBITMQ_HOST
-echo "Waiting for RabbitMQ to Start..."
 
-while ! nc -z $RABBITMQ_HOST 5672; do
-  sleep 0.1
+until timeout 1 bash -c "cat < /dev/null > /dev/tcp/${RABBITMQ_HOST}/5672"; do
+        >&2 echo "Waiting for RabbitMQ at \"${RABBITMQ_HOST}:5672\"..."
+        sleep 1
 done
 
 echo "RabbitMQ started"


### PR DESCRIPTION
Basically, netcat on the `entrypoint.sh` files sometimes would have an issue of infinite loops waiting for RabbitMQ to start, even if it already has started.